### PR TITLE
Style: removed center mode

### DIFF
--- a/src/components/ItemsCarousal/Carousal.jsx
+++ b/src/components/ItemsCarousal/Carousal.jsx
@@ -32,7 +32,6 @@ export default function Carousal() {
         ssr
         infinite
         keyBoardControl
-        centerMode
         focusOnSelect
         itemClass="grid justify-items-center p-5"
       >


### PR DESCRIPTION
it was making problems for the mobile as it would show the right and left items of the list, so I removed it. 

closes: #98